### PR TITLE
SpreadsheetExpressionFunctionsTest.testEvaluateLocaleWithString FIX

### DIFF
--- a/src/test/java/walkingkooka/spreadsheet/expression/function/SpreadsheetExpressionFunctionsTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/expression/function/SpreadsheetExpressionFunctionsTest.java
@@ -2054,17 +2054,11 @@ public final class SpreadsheetExpressionFunctionsTest implements PublicStaticHel
         );
     }
 
-    // https://github.com/mP1/walkingkooka-spreadsheet/issues/5801
     @Test
-    @Disabled
     public void testEvaluateLocaleWithString() {
-        // formatting fails to convert Locale to String for formatting
         this.evaluateAndValueCheck(
-                "=locale(\"EN-AU\")",
-                SpreadsheetErrorKind.VALUE.setMessage("Cannot convert en_AU to String")
-                        .setValue(
-                                Optional.of(Locale.forLanguageTag("en-AU"))
-                        )
+            "=locale(\"en-AU\")",
+            Locale.forLanguageTag("en-AU")
         );
     }
 


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet-expression-function/issues/449
- SpreadsheetExpressionFunctionsTest.testEvaluateLocaleWithString fails because automatic formatter cannot convert Locale to a Number