### PR TITLE
SpreadsheetExpressionFunctionNumberValue: group-separator handling FIX

### DIFF
--- a/src/test/java/walkingkooka/spreadsheet/expression/function/SpreadsheetExpressionFunctionNumberValueTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/expression/function/SpreadsheetExpressionFunctionNumberValueTest.java
@@ -17,7 +17,6 @@
 
 package walkingkooka.spreadsheet.expression.function;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.convert.Converters;
@@ -50,7 +49,19 @@ import java.util.Optional;
 public final class SpreadsheetExpressionFunctionNumberValueTest extends SpreadsheetExpressionFunctionNumberTestCase<SpreadsheetExpressionFunctionNumberValue> {
 
     @Test
-    @Disabled // https://github.com/mP1/walkingkooka-spreadsheet-expression-function/issues/459
+    public void testCustomGroupingSeparator() {
+        this.applyAndCheck(
+            Lists.of(
+                "1G234",
+                'D',
+                'G'
+            ),
+            this.createContext(),
+            EXPRESSION_NUMBER_KIND.create(1234)
+        );
+    }
+
+    @Test
     public void testCustomDecimalSeparatorCustomGroupingSeparator() {
         this.applyAndCheck(
             Lists.of(
@@ -76,7 +87,6 @@ public final class SpreadsheetExpressionFunctionNumberValueTest extends Spreadsh
     }
 
     @Test
-    @Disabled // https://github.com/mP1/walkingkooka-spreadsheet-expression-function/issues/459
     public void testOnlyNumber() {
         this.applyAndCheck(
             Lists.of(


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet-expression-function/issues/459
- SpreadsheetExpressionFunctionNumberValue incomplete support

- Closes https://github.com/mP1/walkingkooka-spreadsheet-expression-function/issues/451
- SpreadsheetExpressionFunctionsTest.testEvaluateNumberValueWithCustomDecimalSeparatorAndGroupSeparator ignoring supplied decimal point and grouping separator because SpreadsheetConverterNumberToText ignores context