### PR TITLE
SpreadsheetExpressionFunctionSpreadsheetMetadataSave

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ found in Sheets or Excel and may be used to interact with features not found in 
 - roundUp
 - row
 - rows
+- saveSpreadsheetMetadata
 - script
 - search
 - second

--- a/src/main/java/walkingkooka/spreadsheet/expression/function/SpreadsheetExpressionFunctionSpreadsheetMetadataSave.java
+++ b/src/main/java/walkingkooka/spreadsheet/expression/function/SpreadsheetExpressionFunctionSpreadsheetMetadataSave.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2022 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.expression.function;
+
+import walkingkooka.collect.list.Lists;
+import walkingkooka.spreadsheet.expression.SpreadsheetExpressionEvaluationContext;
+import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
+import walkingkooka.tree.expression.function.ExpressionFunctionParameter;
+import walkingkooka.tree.expression.function.ExpressionFunctionParameterKind;
+import walkingkooka.tree.expression.function.ExpressionFunctionParameterName;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * A function that may be used to save or replace an {@link SpreadsheetMetadata}
+ */
+final class SpreadsheetExpressionFunctionSpreadsheetMetadataSave extends SpreadsheetExpressionFunctionSpreadsheetMetadata<SpreadsheetMetadata> {
+
+    /**
+     * Singleton
+     */
+    final static SpreadsheetExpressionFunctionSpreadsheetMetadataSave INSTANCE = new SpreadsheetExpressionFunctionSpreadsheetMetadataSave();
+
+    /**
+     * Private constructor use singleton
+     */
+    private SpreadsheetExpressionFunctionSpreadsheetMetadataSave() {
+        super("saveSpreadsheetMetadata");
+    }
+
+    @Override
+    public List<ExpressionFunctionParameter<?>> parameters(final int i) {
+        return PARAMETERS;
+    }
+
+    final static ExpressionFunctionParameter<SpreadsheetMetadata> SPREADSHEET_METADATA = ExpressionFunctionParameterName.with("spreadsheetMetadata")
+        .required(SpreadsheetMetadata.class)
+        .setKinds(ExpressionFunctionParameterKind.CONVERT_EVALUATE_RESOLVE_REFERENCES);
+
+    private final static List<ExpressionFunctionParameter<?>> PARAMETERS = Lists.of(
+        SPREADSHEET_METADATA
+    );
+
+    @Override
+    public Class<SpreadsheetMetadata> returnType() {
+        return SpreadsheetMetadata.class;
+    }
+
+    @Override
+    public SpreadsheetMetadata apply(final List<Object> parameters,
+                                     final SpreadsheetExpressionEvaluationContext context) {
+        Objects.requireNonNull(parameters, "parameters");
+        Objects.requireNonNull(context, "context");
+        System.out.println(parameters.size());
+        System.out.println(parameters);
+        final SpreadsheetMetadata spreadsheetMetadata = SPREADSHEET_METADATA.getOrFail(
+            parameters,
+            0
+        );
+
+        return context.saveMetadata(
+            spreadsheetMetadata
+        );
+    }
+}

--- a/src/main/java/walkingkooka/spreadsheet/expression/function/SpreadsheetExpressionFunctions.java
+++ b/src/main/java/walkingkooka/spreadsheet/expression/function/SpreadsheetExpressionFunctions.java
@@ -1844,6 +1844,13 @@ public final class SpreadsheetExpressionFunctions implements PublicStaticHelper 
     }
 
     /**
+     * {@see SpreadsheetExpressionFunctionSpreadsheetMetadataSave}
+     */
+    public static ExpressionFunction<SpreadsheetMetadata, SpreadsheetExpressionEvaluationContext> saveSpreadsheetMetadata() {
+        return SpreadsheetExpressionFunctionSpreadsheetMetadataSave.INSTANCE;
+    }
+
+    /**
      * {@see StorageExpressionFunctions#script}
      */
     public static ExpressionFunction<Object, SpreadsheetExpressionEvaluationContext> script() {

--- a/src/main/java/walkingkooka/spreadsheet/expression/function/provider/SpreadsheetExpressionFunctionProviders.java
+++ b/src/main/java/walkingkooka/spreadsheet/expression/function/provider/SpreadsheetExpressionFunctionProviders.java
@@ -361,6 +361,7 @@ public final class SpreadsheetExpressionFunctionProviders implements PublicStati
                     SpreadsheetExpressionFunctions.roundUp(),
                     SpreadsheetExpressionFunctions.row(),
                     SpreadsheetExpressionFunctions.rows(),
+                    SpreadsheetExpressionFunctions.saveSpreadsheetMetadata(),
                     SpreadsheetExpressionFunctions.script(),
                     SpreadsheetExpressionFunctions.search(),
                     SpreadsheetExpressionFunctions.second(),

--- a/src/test/java/walkingkooka/spreadsheet/expression/function/SpreadsheetExpressionFunctionSpreadsheetMetadataSaveTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/expression/function/SpreadsheetExpressionFunctionSpreadsheetMetadataSaveTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2022 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.expression.function;
+
+import org.junit.jupiter.api.Test;
+import walkingkooka.collect.list.Lists;
+import walkingkooka.spreadsheet.expression.FakeSpreadsheetExpressionEvaluationContext;
+import walkingkooka.spreadsheet.expression.SpreadsheetExpressionEvaluationContext;
+import walkingkooka.spreadsheet.meta.SpreadsheetId;
+import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
+import walkingkooka.spreadsheet.meta.SpreadsheetMetadataPropertyName;
+import walkingkooka.spreadsheet.meta.SpreadsheetMetadataTesting;
+
+public final class SpreadsheetExpressionFunctionSpreadsheetMetadataSaveTest extends SpreadsheetExpressionFunctionTestCase<SpreadsheetExpressionFunctionSpreadsheetMetadataSave, SpreadsheetMetadata>
+    implements SpreadsheetMetadataTesting {
+
+    private final static SpreadsheetId SPREADSHEET_ID = SpreadsheetId.with(1);
+
+    private final static SpreadsheetMetadata UNSAVED_METADATA = METADATA_EN_AU;
+
+    private final static SpreadsheetMetadata SAVED_METADATA = UNSAVED_METADATA.set(
+        SpreadsheetMetadataPropertyName.SPREADSHEET_ID,
+        SPREADSHEET_ID
+    );
+
+    @Test
+    public void testApply() {
+        this.applyAndCheck(
+            Lists.of(UNSAVED_METADATA),
+            SAVED_METADATA
+        );
+    }
+
+    @Override
+    public SpreadsheetExpressionFunctionSpreadsheetMetadataSave createBiFunction() {
+        return SpreadsheetExpressionFunctionSpreadsheetMetadataSave.INSTANCE;
+    }
+
+    @Override
+    public SpreadsheetExpressionEvaluationContext createContext() {
+        return new FakeSpreadsheetExpressionEvaluationContext() {
+
+            @Override
+            public SpreadsheetMetadata saveMetadata(final SpreadsheetMetadata metadata) {
+                checkEquals(
+                    UNSAVED_METADATA,
+                    metadata
+                );
+
+                return SAVED_METADATA;
+            }
+        };
+    }
+
+    @Override
+    public int minimumParameterCount() {
+        return 1;
+    }
+
+    // toString.........................................................................................................
+
+    @Test
+    public void testToString() {
+        this.toStringAndCheck(
+            this.createBiFunction(),
+            "saveSpreadsheetMetadata"
+        );
+    }
+
+    // class............................................................................................................
+
+    @Override
+    public Class<SpreadsheetExpressionFunctionSpreadsheetMetadataSave> type() {
+        return SpreadsheetExpressionFunctionSpreadsheetMetadataSave.class;
+    }
+}

--- a/src/test/java/walkingkooka/spreadsheet/expression/function/SpreadsheetExpressionFunctionsTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/expression/function/SpreadsheetExpressionFunctionsTest.java
@@ -3660,6 +3660,36 @@ public final class SpreadsheetExpressionFunctionsTest implements PublicStaticHel
     }
 
     @Test
+    public void testEvaluateSaveSpreadsheetMetadata() {
+        this.checkEquals(
+            SPREADSHEET_ID,
+            SpreadsheetId.with(0x1234)
+        );
+
+        final SpreadsheetMetadata expected = this.metadata()
+            .set(
+                SpreadsheetMetadataPropertyName.SPREADSHEET_ID,
+                SPREADSHEET_ID
+            ).set(
+                SpreadsheetMetadataPropertyName.SPREADSHEET_NAME,
+                SpreadsheetName.with("Hello")
+            );
+
+        final SpreadsheetEngineContext context = this.evaluateAndPrintedCheck(
+            "=saveSpreadsheetMetadata(setSpreadsheetMetadataValue(loadSpreadsheetMetadata(\"1234\"),\"spreadsheetName\",\"Hello\"))",
+            expected, // expected value
+            "" // expected printed
+        );
+
+        this.checkEquals(
+            expected,
+            context.loadMetadata(SPREADSHEET_ID)
+                .orElse(null),
+            "Unable to load saved SpreadsheetMetadata"
+        );
+    }
+
+    @Test
     public void testEvaluateScript() {
         final EnvironmentContext environmentContext = EnvironmentContexts.map(
             EnvironmentContexts.empty(


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet-expression-function/issues/305
- ExpressionFunction: saveSpreadsheetMetadata saves a new SpreadsheetMetadata