### PR TITLE
SpreadsheetExpressionFunctionsTest.testEvaluateGetDateTimeSymbolsWith…

### DIFF
--- a/src/test/java/walkingkooka/spreadsheet/expression/function/SpreadsheetExpressionFunctionsTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/expression/function/SpreadsheetExpressionFunctionsTest.java
@@ -1567,8 +1567,7 @@ public final class SpreadsheetExpressionFunctionsTest implements PublicStaticHel
         );
     }
 
-    @Disabled("Converter: HasDateTimeSymbols: https://github.com/mP1/walkingkooka-convert/issues/569")
-    //@Test
+    @Test
     public void testEvaluateGetDateTimeSymbolsWithSpreadsheetCell() {
         final DateTimeSymbols dateTimeSymbols = DateTimeSymbols.fromDateFormatSymbols(
             DateFormatSymbols.getInstance(Locale.FRENCH)


### PR DESCRIPTION
…SpreadsheetCell reenabled

- Closes https://github.com/mP1/walkingkooka-spreadsheet-expression-function/issues/864
- re-enable testEvaluateGetDateTimeSymbolsWithSpreadsheetCell after HasDateTimeSymbols Converter